### PR TITLE
Explicitly set subnetType for DatabaseInstance

### DIFF
--- a/cdk/lib/hasura-stack.ts
+++ b/cdk/lib/hasura-stack.ts
@@ -40,6 +40,7 @@ export class HasuraStack extends Stack {
             allocatedStorage: 20,
             maxAllocatedStorage: 100,
             vpc: props.vpc,
+            vpcSubnets: { subnetType: SubnetType.ISOLATED },
             deletionProtection: false,
             multiAz: props.multiAz,
             removalPolicy: RemovalPolicy.DESTROY,


### PR DESCRIPTION
Newer versions of the CDK requires to specify subnetType for DatabaseInstance.